### PR TITLE
Move temporary mode logic to class initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ user_properties = pd.DataFrame({
     "membership_status": ["Free", "Free", "Free", "Free", "Free"]
 })
 
-analyzer = VariatioAnalyzer(event_data, user_allocations, "A", user_properties)
+analyzer = VariatioAnalyzer(event_data, user_allocations, "A", user_properties, mode="catboost_cuped")
 ```
 
 You can then calculate various metrics such as event count per user, attribute sum per user (useful for calculating metrics like ARPU), or conversion rates to specific events:

--- a/data_generation/data_generator.py
+++ b/data_generation/data_generator.py
@@ -113,12 +113,18 @@ def create_dataframes(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame, pd.
 
 def run_analysis(df: pd.DataFrame):
     event_data, user_allocations, user_properties = create_dataframes(df)
+    
+    # Analysis without enhancement
+    analyzer_no_enhancement = VariatioAnalyzer(event_data, user_allocations, "a1", user_properties, mode="no_enhancement")
+    results_no_enhancement = analyzer_no_enhancement.calculate_event_attribute_sum_per_user('purchase', 'purchase_value')
 
-    analyzer = VariatioAnalyzer(event_data, user_allocations, "a1", user_properties)
+    # Analysis with CUPED
+    analyzer_cuped = VariatioAnalyzer(event_data, user_allocations, "a1", user_properties, mode="cuped")
+    results_cuped = analyzer_cuped.calculate_event_attribute_sum_per_user('purchase', 'purchase_value')
 
-    results_no_enhancement = analyzer.calculate_event_attribute_sum_per_user('purchase', 'purchase_value', "no_enhancement")
-    results_cuped = analyzer.calculate_event_attribute_sum_per_user('purchase', 'purchase_value', "cuped")
-    results_catboost_cuped = analyzer.calculate_event_attribute_sum_per_user('purchase', 'purchase_value', "catboost_cuped")
+    # Analysis with CatBoost CUPED
+    analyzer_catboost_cuped = VariatioAnalyzer(event_data, user_allocations, "a1", user_properties, mode="catboost_cuped")
+    results_catboost_cuped = analyzer_catboost_cuped.calculate_event_attribute_sum_per_user('purchase', 'purchase_value')
 
     return {
         "no_enhancement": results_no_enhancement,

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "analyzer = VariatioAnalyzer(event_data, user_allocations, \"A\")"
+    "analyzer = VariatioAnalyzer(event_data, user_allocations, \"A\", mode=\"catboost_cuped\")"
    ]
   },
   {

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -10,10 +10,10 @@ def test_library_is_initialized():
     ab_test_allocations = generate_user_allocations()
 
     # initializing with user properties
-    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties)
+    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="catboost_cuped")
 
     # initializing without user properties
-    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A")
+    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="catboost_cuped")
 
 
 def test_library_is_not_initialized():
@@ -24,7 +24,7 @@ def test_library_is_not_initialized():
 
     # initializing without user properties
     with pytest.raises(Exception) as e_info:
-        VariatioAnalyzer(event_data, ab_test_allocations, "A")
+        VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="catboost_cuped")
     assert str("The 'timestamp' column in event_data must be of datetime type.") == str(e_info.value)
 
 
@@ -35,7 +35,7 @@ def test_calculate_metrics(user_properties):
     event_data = generate_event_data()
     ab_test_allocations = generate_user_allocations()
 
-    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties)
+    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="catboost_cuped")
 
     event_counts = analyzer.calculate_event_count_per_user('purchase')
 
@@ -67,8 +67,8 @@ def test_calculate_significance():
     ab_test_allocations = generate_user_allocations()
 
     user_properties = generate_user_properties()
-    analyzer_user_properties = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties)
-    analyzer_no_user_properties = VariatioAnalyzer(event_data, ab_test_allocations, "A")
+    analyzer_user_properties = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="catboost_cuped")
+    analyzer_no_user_properties = VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="catboost_cuped")
 
     analyzer_user_properties.calculate_event_count_per_user('purchase')
     analyzer_no_user_properties.calculate_event_count_per_user('purchase')


### PR DESCRIPTION
### Description

This PR refactors the `VariatioAnalyzer` class to move the temporary mode logic ("no_enhancement", "cuped", "catboost_cuped") to the class initialization. This change ensures that the mode is set during the creation of an instance and simplifies the method calls within the class.

### Changes

- **Added** a `mode` parameter to the constructor of the `VariatioAnalyzer` class.
- **Updated** methods to use the `mode` attribute from the instance rather than passing it as a parameter.
- **Refactored** the `run_analysis` function in `data_generation/data_generator.py` to create separate instances of `VariatioAnalyzer` for each mode.

### Benefits

- Improved code readability and maintainability.
- Simplified method calls by eliminating the need to pass the `mode` parameter each time.
- Ensured consistency by setting the mode once during the instance creation.

### Testing

- Verified that the `run_analysis` function produces the same results for all three modes (`no_enhancement`, `cuped`, `catboost_cuped`).
- Ran existing unit tests to ensure no regressions were introduced.