### PR TITLE
Replace all references to catboost with gboost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,17 +152,6 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
-# PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
-/catboost_info/
-/results.html
-/tests/catboost_info/
-/examples/catboost_info/
-
 # Ignore all files and folders in data. Except the placeholder file.
 data/*
 !data/.placeholder

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 [![GitHub Issues](https://img.shields.io/github/issues/dmitry-brazhenko/Variatio.svg)](https://github.com/dmitry-brazhenko/Variatio/issues)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Variatio is an experimental Python library designed for advanced A/B testing analysis. It leverages statistical techniques and machine learning, including variance reduction through CUPED and integration with CatBoost for predictive insights. Variatio is ideal for data scientists and researchers looking to obtain deeper insights from their A/B testing efforts.
+Variatio is an experimental Python library designed for advanced A/B testing analysis. It leverages statistical techniques and machine learning, including variance reduction through CUPED and integration with XGBoost for predictive insights. Variatio is ideal for data scientists and researchers looking to obtain deeper insights from their A/B testing efforts.
 
 ## Features
 
 This tool streamlines A/B testing by automatically calculating all the classic metrics behind the scenes. Simply provide your data, and it will compute the metrics you request, delivering them in a visually appealing report. Here are some of the key features:
 
 - **Statistical Significance Testing:** Easily compare metrics between control and test groups, with all necessary calculations done for you.
-- **CUPED Adjustments:** This experimental extension utilizes Controlled-experiment Using Pre-Experiment Data (CUPED) techniques for variance reduction. It innovatively employs user properties as covariates and leverages CatBoost regression, moving beyond traditional linear approaches to enhance A/B test sensitivity.
+- **CUPED Adjustments:** This experimental extension utilizes Controlled-experiment Using Pre-Experiment Data (CUPED) techniques for variance reduction. It innovatively employs user properties as covariates and leverages XGBoost regression, moving beyond traditional linear approaches to enhance A/B test sensitivity.
 
 
 
@@ -122,7 +122,7 @@ user_properties = pd.DataFrame({
     "membership_status": ["Free", "Free", "Free", "Free", "Free"]
 })
 
-analyzer = VariatioAnalyzer(event_data, user_allocations, "A", user_properties, mode="catboost_cuped")
+analyzer = VariatioAnalyzer(event_data, user_allocations, "A", user_properties, mode="gboost_cuped")
 ```
 
 You can then calculate various metrics such as event count per user, attribute sum per user (useful for calculating metrics like ARPU), or conversion rates to specific events:

--- a/data_generation/data_generator.py
+++ b/data_generation/data_generator.py
@@ -122,14 +122,14 @@ def run_analysis(df: pd.DataFrame):
     analyzer_cuped = VariatioAnalyzer(event_data, user_allocations, "a1", user_properties, mode="cuped")
     results_cuped = analyzer_cuped.calculate_event_attribute_sum_per_user('purchase', 'purchase_value')
 
-    # Analysis with CatBoost CUPED
-    analyzer_catboost_cuped = VariatioAnalyzer(event_data, user_allocations, "a1", user_properties, mode="catboost_cuped")
-    results_catboost_cuped = analyzer_catboost_cuped.calculate_event_attribute_sum_per_user('purchase', 'purchase_value')
+    # Analysis with gboost CUPED
+    analyzer_gboost_cuped = VariatioAnalyzer(event_data, user_allocations, "a1", user_properties, mode="gboost_cuped")
+    results_gboost_cuped = analyzer_gboost_cuped.calculate_event_attribute_sum_per_user('purchase', 'purchase_value')
 
     return {
         "no_enhancement": results_no_enhancement,
         "cuped": results_cuped,
-        "catboost_cuped": results_catboost_cuped
+        "gboost_cuped": results_gboost_cuped
     }
 
 if __name__ == "__main__":
@@ -154,4 +154,4 @@ if __name__ == "__main__":
     results = run_analysis(generated_data)
     print("Analysis results (no enhancement):", results["no_enhancement"])
     print("Analysis results (cuped):", results["cuped"])
-    print("Analysis results (catboost_cuped):", results["catboost_cuped"])
+    print("Analysis results (gboost_cuped):", results["gboost_cuped"])

--- a/examples/abtest_report_xgboost.html
+++ b/examples/abtest_report_xgboost.html
@@ -1,0 +1,17 @@
+
+    <style>
+        body {display: flex; justify-content: center; margin: 0; height: 100vh; align-items: center;}
+        table {border-collapse: collapse; width: 80%; margin: auto;}
+        td, th {text-align: center; padding: 8px; border: 1px solid #ddd;}
+        td, th {min-width: 100px; max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;}
+        table {table-layout: fixed; width: auto;}
+        th {background-color: #f2f2f2;}
+        .grey {background-color: grey;}
+        .lightgreen {background-color: lightgreen;}
+        .lightcoral {background-color: lightcoral;}
+        .green {background-color: green;}
+        .red {background-color: red;}
+        tr:hover {background-color: #f5f5f5;}
+    </style>
+    <table>
+        <tr><th>Metric</th><th>A</th><th>B</th></tr><tr><td>Count of 'purchase' events per user.</td><td>0.04</td><td class="green" title="P-value: 0.0000">0.16<br/>(278%)</td></tr><tr><td>Sum of 'purchase_value' for 'purchase' events per user.</td><td>8.35</td><td class="green" title="P-value: 0.0000">32.45<br/>(289%)</td></tr><tr><td>Conversion rate to 'login' event per user.</td><td>0.08</td><td class="green" title="P-value: 0.0000">0.31<br/>(260%)</td></tr></table>

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -125,7 +125,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "analyzer = VariatioAnalyzer(event_data, user_allocations, \"A\", mode=\"catboost_cuped\")"
+    "analyzer = VariatioAnalyzer(event_data, user_allocations, \"A\", mode=\"gboost_cuped\")"
    ]
   },
   {
@@ -137,10 +137,37 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "QQQQQ\n",
-      "model was fit\n",
-      "QQQQQ\n",
-      "model was fit\n",
+      "use_enhansement False\n",
+      "use_enhansement True\n",
+      "        purchase_value\n",
+      "userid                \n",
+      "1                  0.0\n",
+      "5                  0.0\n",
+      "6                  0.0\n",
+      "7                  0.0\n",
+      "11                 0.0\n",
+      "...                ...\n",
+      "9992               0.0\n",
+      "9993               0.0\n",
+      "9995               0.0\n",
+      "9999               0.0\n",
+      "10000              0.0\n",
+      "\n",
+      "[5076 rows x 1 columns]\n",
+      "userid\n",
+      "1        0.0\n",
+      "5        0.0\n",
+      "6        0.0\n",
+      "7        0.0\n",
+      "11       0.0\n",
+      "        ... \n",
+      "9992     0.0\n",
+      "9993     0.0\n",
+      "9995     0.0\n",
+      "9999     0.0\n",
+      "10000    0.0\n",
+      "Name: purchase_value, Length: 5076, dtype: float64\n",
+      "model wast\n",
       "Metrics were calculated\n"
      ]
     }
@@ -180,8 +207,8 @@
     {
      "data": {
       "text/plain": [
-       "[<Metric(metrictype=MetricType.EVENT_COUNT_PER_USER, metricparams=<MetricParams({'event_name': 'purchase'})>, result=<MetricResult(control_group=A, test_groups=['B'], data={'A': 0.043538219070133964, 'B': 0.1645004061738424}, stat_significance={'B': 5.624376787379325e-70}, stat_significance_method=StatSignificanceMethod.CATBOOST_CUPED_T_TEST)>)>,\n",
-       " <Metric(metrictype=MetricType.EVENT_ATTRIBUTE_SUM_PER_USER, metricparams=<MetricParams({'event_name': 'purchase', 'attribute_name': 'purchase_value'})>, result=<MetricResult(control_group=A, test_groups=['B'], data={'A': 8.345350669818755, 'B': 32.451868399675064}, stat_significance={'B': 9.318010357754765e-62}, stat_significance_method=StatSignificanceMethod.CATBOOST_CUPED_T_TEST)>)>,\n",
+       "[<Metric(metrictype=MetricType.EVENT_COUNT_PER_USER, metricparams=<MetricParams({'event_name': 'purchase'})>, result=<MetricResult(control_group=A, test_groups=['B'], data={'A': 0.043538219070133964, 'B': 0.1645004061738424}, stat_significance={'B': 1.3718487012578476e-71}, stat_significance_method=StatSignificanceMethod.GBOOST_CUPED_T_TEST)>)>,\n",
+       " <Metric(metrictype=MetricType.EVENT_ATTRIBUTE_SUM_PER_USER, metricparams=<MetricParams({'event_name': 'purchase', 'attribute_name': 'purchase_value'})>, result=<MetricResult(control_group=A, test_groups=['B'], data={'A': 8.345350669818755, 'B': 32.451868399675064}, stat_significance={'B': 9.318010357754765e-62}, stat_significance_method=StatSignificanceMethod.GBOOST_CUPED_T_TEST)>)>,\n",
        " <Metric(metrictype=MetricType.CONVERSION_RATE, metricparams=<MetricParams({'event_name': 'login'})>, result=<MetricResult(control_group=A, test_groups=['B'], data={'A': 0.08490937746256895, 'B': 0.30584890333062553}, stat_significance={'B': 7.418608501468872e-175}, stat_significance_method=StatSignificanceMethod.T_TEST)>)>]"
       ]
      },
@@ -234,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.6"
+   "version": "3.11.8"
   }
  },
  "nbformat": 4,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 scikit-learn>=1.2.0
-catboost>=1.2.3
 pandas>=1.4.0
 scipy>=1.10.0
 xgboost

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -54,17 +54,17 @@ class TestDataGenerator(unittest.TestCase):
         # Check if the analysis results are not empty
         self.assertTrue("no_enhancement" in results)
         self.assertTrue("cuped" in results)
-        self.assertTrue("catboost_cuped" in results)
+        self.assertTrue("gboost_cuped" in results)
         
         # Further checks can be added based on expected structure of results
         self.assertIsInstance(results["no_enhancement"][0], pd.DataFrame)
         self.assertIsInstance(results["cuped"][0], pd.DataFrame)
-        self.assertIsInstance(results["catboost_cuped"][0], pd.DataFrame)
+        self.assertIsInstance(results["gboost_cuped"][0], pd.DataFrame)
 
         # Check if second element is StatSignificanceResult
         self.assertIsInstance(results["no_enhancement"][1], StatSignificanceResult)
         self.assertIsInstance(results["cuped"][1], StatSignificanceResult)
-        self.assertIsInstance(results["catboost_cuped"][1], StatSignificanceResult)
+        self.assertIsInstance(results["gboost_cuped"][1], StatSignificanceResult)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -10,10 +10,10 @@ def test_library_is_initialized():
     ab_test_allocations = generate_user_allocations()
 
     # initializing with user properties
-    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="catboost_cuped")
+    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="gboost_cuped")
 
     # initializing without user properties
-    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="catboost_cuped")
+    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="gboost_cuped")
 
 
 def test_library_is_not_initialized():
@@ -24,7 +24,7 @@ def test_library_is_not_initialized():
 
     # initializing without user properties
     with pytest.raises(Exception) as e_info:
-        VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="catboost_cuped")
+        VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="gboost_cuped")
     assert str("The 'timestamp' column in event_data must be of datetime type.") == str(e_info.value)
 
 
@@ -35,7 +35,7 @@ def test_calculate_metrics(user_properties):
     event_data = generate_event_data()
     ab_test_allocations = generate_user_allocations()
 
-    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="catboost_cuped")
+    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="gboost_cuped")
 
     event_counts = analyzer.calculate_event_count_per_user('purchase')
 
@@ -67,8 +67,8 @@ def test_calculate_significance():
     ab_test_allocations = generate_user_allocations()
 
     user_properties = generate_user_properties()
-    analyzer_user_properties = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="catboost_cuped")
-    analyzer_no_user_properties = VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="catboost_cuped")
+    analyzer_user_properties = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="gboost_cuped")
+    analyzer_no_user_properties = VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="gboost_cuped")
 
     analyzer_user_properties.calculate_event_count_per_user('purchase')
     analyzer_no_user_properties.calculate_event_count_per_user('purchase')

--- a/variatio/analyzer.py
+++ b/variatio/analyzer.py
@@ -10,17 +10,17 @@ from variatio.vizualizer import format_metrics_to_html
 
 class VariatioAnalyzer:
     def __init__(self, event_data: pd.DataFrame, ab_test_allocations: pd.DataFrame, control_group_name: str,
-                 user_properties: Optional[pd.DataFrame] = None, mode="catboost_cuped"):
+                 user_properties: Optional[pd.DataFrame] = None, mode="gboost_cuped"):
         """
         Initializes the VariatioAnalyzer with event data, AB test allocations, control group name, user properties, and mode.
         :param event_data: DataFrame containing event data. Expected pandas format: |timestamp|userid|event_name|attribute_1|attribute_2|...
         :param ab_test_allocations: DataFrame containing AB test allocations. Expected pandas format: |timestamp|userid|abgroup|
         :param control_group_name: The name of the control group.
         :param user_properties: DataFrame containing user properties. Expected pandas format: |userid|property_1|property_2|...
-        :param mode: Mode of enhancement ("no_enhancement", "cuped", "catboost_cuped").
+        :param mode: Mode of enhancement ("no_enhancement", "cuped", "gboost_cuped").
         """
 
-        assert mode in ["no_enhancement", "cuped", "catboost_cuped"], "Invalid mode"
+        assert mode in ["no_enhancement", "cuped", "gboost_cuped"], "Invalid mode"
 
         self.control_group_name = control_group_name
         self.test_group_names = [group for group in ab_test_allocations['abgroup'].unique() if
@@ -94,7 +94,7 @@ class VariatioAnalyzer:
 
         merged_intest, result_intest = self._merge_and_aggregate(self.event_data, self.ab_test_allocations, event_name,
                                                                  AggregationOperation.COUNT)
-        stat_test = StatTests.calculate_catboost_cuped_and_compare(merged_pretest, merged_intest, self.user_properties,
+        stat_test = StatTests.calculate_gboost_cuped_and_compare(merged_pretest, merged_intest, self.user_properties,
                                                                    self.control_group_name, self.test_group_names)
 
         self.calculated_metrics.append(Metric(MetricType.EVENT_COUNT_PER_USER, MetricParams(event_name),
@@ -121,14 +121,14 @@ class VariatioAnalyzer:
         merged_intest, result_intest = self._merge_and_aggregate(self.event_data, self.ab_test_allocations, event_name,
                                                                 AggregationOperation.SUM, attribute_name)
 
-        if self.mode == "catboost_cuped":
-            stat_test = StatTests.calculate_catboost_cuped_and_compare(merged_pretest, merged_intest, self.user_properties,
+        if self.mode == "gboost_cuped":
+            stat_test = StatTests.calculate_gboost_cuped_and_compare(merged_pretest, merged_intest, self.user_properties,
                                                                 self.control_group_name, self.test_group_names, True)
         elif self.mode == "cuped":
             stat_test = StatTests.calculate_cuped_and_compare(merged_pretest, merged_intest,
                                                                 self.control_group_name, self.test_group_names)
         else:
-            stat_test = StatTests.calculate_catboost_cuped_and_compare(merged_pretest, merged_intest,
+            stat_test = StatTests.calculate_gboost_cuped_and_compare(merged_pretest, merged_intest,
                                                                     self.user_properties,
                                                                     self.control_group_name, self.test_group_names,
                                                                     False)

--- a/variatio/stat_significance.py
+++ b/variatio/stat_significance.py
@@ -2,7 +2,6 @@ from enum import Enum, auto
 from typing import List, Union, Optional
 
 import numpy as np
-from catboost import CatBoostRegressor
 from scipy import stats
 from sklearn.compose import ColumnTransformer
 from sklearn.dummy import DummyRegressor
@@ -18,7 +17,7 @@ class StatSignificanceMethod(Enum):
     CHI_SQUARE = auto()
     T_TEST = auto()
     PURE_CUPED_T_TEST = auto()
-    CATBOOST_CUPED_T_TEST = auto()
+    GBOOST_CUPED_T_TEST = auto()
 
 
 class StatSignificanceResult:
@@ -120,7 +119,7 @@ class StatTests:
         return StatSignificanceResult(StatSignificanceMethod.PURE_CUPED_T_TEST, p_values)
 
     @staticmethod
-    def calculate_catboost_cuped_and_compare(merged_pretest: pd.DataFrame, merged_intest: pd.DataFrame,
+    def calculate_gboost_cuped_and_compare(merged_pretest: pd.DataFrame, merged_intest: pd.DataFrame,
                                              user_properties: Optional[pd.DataFrame], control_group: str,
                                              test_groups: List[str], use_enhansement: bool = False) -> StatSignificanceResult:
         """
@@ -205,4 +204,4 @@ class StatTests:
                 test_group_names.append(test_group)
 
         # Assuming StatSignificanceResult is a structure you've defined to store the results
-        return StatSignificanceResult(StatSignificanceMethod.CATBOOST_CUPED_T_TEST, p_values)
+        return StatSignificanceResult(StatSignificanceMethod.GBOOST_CUPED_T_TEST, p_values)


### PR DESCRIPTION
# Refactor: Replace all references to catboost with gboost

## Summary

This pull request refactors the codebase to replace all references to `catboost` with `gboost`. The goal is to use a more generic term related to gradient boosting without specifying a particular library implementation.

## Changes

- Replaced `catboost` imports and class names with `gboost` in all relevant files.
- Updated function names and comments to reflect the change from `catboost` to `gboost`.
- Ensured that no `catboost` references remain in the codebase.