### PR TITLE
Feature/correlated-data-generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,3 +155,6 @@ cython_debug/
 # Ignore all files and folders in data. Except the placeholder file.
 data/*
 !data/.placeholder
+
+# Mac OS
+.DS_Store

--- a/data_generation/data_generator.py
+++ b/data_generation/data_generator.py
@@ -156,7 +156,8 @@ if __name__ == "__main__":
         user_segments=['Segment_1', 'Segment_2', 'Segment_3', 'Segment_4'],
         ab_groups=['a1', 'a2', 'b'],
         noise_level=1.0,
-        base_increase_percentage=0.05
+        base_increase_percentage=0.05,
+        correlation_level=0.5,
     )
 
     # Save the data to a CSV file

--- a/data_generation/data_generator.py
+++ b/data_generation/data_generator.py
@@ -67,13 +67,22 @@ def generate_synthetic_data(num_users, countries, platforms, user_segments, ab_g
         np.random.uniform(-2 * base_increase_percentage, base_increase_percentage * 2, num_users),
     )
 
+    # Define mean and covariance for multivariate normal distribution
+    mean = [0, 0]
+    cov = [[1, correlation_level], [correlation_level, 1]]
+    
+    # Generate correlated values for 'value' and 'pre_test_value'
+    correlated_values = np.random.multivariate_normal(mean, cov, num_users)
+
+    # Calculate the noise
+    noise = np.random.normal(0, noise_level, num_users)
+
     # Calculate the final value with added nonlinear category effect and noise
-    df['value'] = base_value * (1 + category_effect) * (1 + group_effect) + np.random.normal(0, noise_level, num_users)
+    df['value'] = base_value * (1 + category_effect) * (1 + group_effect) + correlated_values[:, 0] + noise
 
     # Generating pre-test value with a slightly different formula to introduce non-linearity and noise
-    noise = np.random.normal(-1, 1, num_users)
     nonlinear_component = 0.5 * np.sin(df['engagement_score'] / 2) * np.random.uniform(-1, 1, num_users)
-    df['pre_test_value'] = base_value * (1 + np.random.normal(1, 0.5, num_users) * category_effect) * (1 + np.random.normal(0, 0.05, num_users)) + nonlinear_component + noise
+    df['pre_test_value'] = base_value * (1 + category_effect) * (1 + correlated_values[:, 1]) + nonlinear_component + noise
 
 
     describe_dataset(df)

--- a/data_generation/data_generator.py
+++ b/data_generation/data_generator.py
@@ -29,7 +29,7 @@ def describe_dataset(df):
     ab_means = df.groupby('abgroup')['value'].mean()
     logging.info(ab_means)
 
-def generate_synthetic_data(num_users, countries, platforms, user_segments, ab_groups, base_increase_percentage, noise_level=1.0, seed=40):
+def generate_synthetic_data(num_users, countries, platforms, user_segments, ab_groups, base_increase_percentage, noise_level=1.0, correlation_level=0.5, seed=40):
     # Set seed for reproducibility
     np.random.seed(seed)
     
@@ -71,9 +71,9 @@ def generate_synthetic_data(num_users, countries, platforms, user_segments, ab_g
     df['value'] = base_value * (1 + category_effect) * (1 + group_effect) + np.random.normal(0, noise_level, num_users)
 
     # Generating pre-test value with a slightly different formula to introduce non-linearity and noise
-    df['pre_test_value'] = base_value * (1 + np.random.normal(1, 0.5, num_users) * category_effect) * (1 + np.random.normal(0, 0.05, num_users)) + \
-                        0.5 * np.sin(df['engagement_score'] / 2) * np.random.uniform(-1, 1, num_users) + \
-                        np.random.normal(-1, 1, num_users)  # Adding more noise for pre-test value
+    noise = np.random.normal(-1, 1, num_users)
+    nonlinear_component = 0.5 * np.sin(df['engagement_score'] / 2) * np.random.uniform(-1, 1, num_users)
+    df['pre_test_value'] = base_value * (1 + np.random.normal(1, 0.5, num_users) * category_effect) * (1 + np.random.normal(0, 0.05, num_users)) + nonlinear_component + noise
 
 
     describe_dataset(df)

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -33,12 +33,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from variatio import VariatioAnalyzer"
+    "from ab_test_advanced_toolkit import VariatioAnalyzer"
    ]
   },
   {
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -121,7 +121,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,16 +130,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
+     "name": "stderr",
      "output_type": "stream",
      "text": [
-      "use_enhansement False\n",
-      "use_enhansement True\n",
-      "        purchase_value\n",
+      "2024-05-21 11:11:48,722 - INFO - X_control:         event_name\n",
+      "userid            \n",
+      "1              0.0\n",
+      "5              0.0\n",
+      "6              0.0\n",
+      "7              0.0\n",
+      "11             0.0\n",
+      "...            ...\n",
+      "9992           0.0\n",
+      "9993           0.0\n",
+      "9995           0.0\n",
+      "9999           0.0\n",
+      "10000          0.0\n",
+      "\n",
+      "[5076 rows x 1 columns]\n",
+      "2024-05-21 11:11:48,755 - INFO - Model was fit\n",
+      "2024-05-21 11:11:48,770 - INFO - X_control:         purchase_value\n",
       "userid                \n",
       "1                  0.0\n",
       "5                  0.0\n",
@@ -154,20 +168,13 @@
       "10000              0.0\n",
       "\n",
       "[5076 rows x 1 columns]\n",
-      "userid\n",
-      "1        0.0\n",
-      "5        0.0\n",
-      "6        0.0\n",
-      "7        0.0\n",
-      "11       0.0\n",
-      "        ... \n",
-      "9992     0.0\n",
-      "9993     0.0\n",
-      "9995     0.0\n",
-      "9999     0.0\n",
-      "10000    0.0\n",
-      "Name: purchase_value, Length: 5076, dtype: float64\n",
-      "model wast\n",
+      "2024-05-21 11:11:48,805 - INFO - Model was fit\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Metrics were calculated\n"
      ]
     }
@@ -201,18 +208,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "[<Metric(metrictype=MetricType.EVENT_COUNT_PER_USER, metricparams=<MetricParams({'event_name': 'purchase'})>, result=<MetricResult(control_group=A, test_groups=['B'], data={'A': 0.043538219070133964, 'B': 0.1645004061738424}, stat_significance={'B': 1.3718487012578476e-71}, stat_significance_method=StatSignificanceMethod.GBOOST_CUPED_T_TEST)>)>,\n",
+       "[<Metric(metrictype=MetricType.EVENT_COUNT_PER_USER, metricparams=<MetricParams({'event_name': 'purchase'})>, result=<MetricResult(control_group=A, test_groups=['B'], data={'A': 0.043538219070133964, 'B': 0.1645004061738424}, stat_significance={'B': 5.624376787379325e-70}, stat_significance_method=StatSignificanceMethod.GBOOST_CUPED_T_TEST)>)>,\n",
        " <Metric(metrictype=MetricType.EVENT_ATTRIBUTE_SUM_PER_USER, metricparams=<MetricParams({'event_name': 'purchase', 'attribute_name': 'purchase_value'})>, result=<MetricResult(control_group=A, test_groups=['B'], data={'A': 8.345350669818755, 'B': 32.451868399675064}, stat_significance={'B': 9.318010357754765e-62}, stat_significance_method=StatSignificanceMethod.GBOOST_CUPED_T_TEST)>)>,\n",
        " <Metric(metrictype=MetricType.CONVERSION_RATE, metricparams=<MetricParams({'event_name': 'login'})>, result=<MetricResult(control_group=A, test_groups=['B'], data={'A': 0.08490937746256895, 'B': 0.30584890333062553}, stat_significance={'B': 7.418608501468872e-175}, stat_significance_method=StatSignificanceMethod.T_TEST)>)>]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -230,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tempfile.html
+++ b/tempfile.html
@@ -1,0 +1,17 @@
+
+    <style>
+        body {display: flex; justify-content: center; margin: 0; height: 100vh; align-items: center;}
+        table {border-collapse: collapse; width: 80%; margin: auto;}
+        td, th {text-align: center; padding: 8px; border: 1px solid #ddd;}
+        td, th {min-width: 100px; max-width: 400px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;}
+        table {table-layout: fixed; width: auto;}
+        th {background-color: #f2f2f2;}
+        .grey {background-color: grey;}
+        .lightgreen {background-color: lightgreen;}
+        .lightcoral {background-color: lightcoral;}
+        .green {background-color: green;}
+        .red {background-color: red;}
+        tr:hover {background-color: #f5f5f5;}
+    </style>
+    <table>
+        <tr><th>Metric</th><th>A</th><th>B</th></tr><tr><td>Count of 'purchase' events per user.</td><td>0.28</td><td class="grey" title="P-value: 0.6401">0.40<br/>(43%)</td></tr><tr><td>Sum of 'purchase_value' for 'purchase' events per user.</td><td>53.28</td><td class="grey" title="P-value: 0.4849">91.55<br/>(72%)</td></tr><tr><td>Conversion rate to 'purchase' event per user.</td><td>0.08</td><td class="grey" title="P-value: 0.8615">0.09<br/>(13%)</td></tr></table>

--- a/tests/test_data_generator.py
+++ b/tests/test_data_generator.py
@@ -21,7 +21,8 @@ class TestDataGenerator(unittest.TestCase):
             user_segments=user_segments,
             ab_groups=ab_groups,
             noise_level=1.0,
-            base_increase_percentage=0.05
+            base_increase_percentage=0.05,
+            correlation_level=0.5,
         )
         
         # Check if the data is generated correctly
@@ -48,7 +49,8 @@ class TestDataGenerator(unittest.TestCase):
             user_segments=user_segments,
             ab_groups=ab_groups,
             noise_level=1.0,
-            base_increase_percentage=0.05
+            base_increase_percentage=0.05,
+            correlation_level=0.5,
         )
         
         results = run_analysis(data)


### PR DESCRIPTION
#### Summary:
This PR enhances the existing synthetic data generation function to include controlled correlation between 'value' and 'pre_test_value'. This improvement is essential for testing and validating the CUPED (Controlled Experiment Using Pre-Experiment Data) methodology, specifically for the CUPED_GBOOST model.

#### Key Changes:
1. **Correlation Introduction**:
   - Added a mechanism to introduce and control correlation between 'value' and 'pre_test_value' using a multivariate normal distribution.
   - The correlation level is adjustable via the `correlation_level` parameter, allowing for flexible experimentation.

2. **Synthetic Data Structure**:
   - Retained the existing structure for generating user data, including attributes like `userid`, `country`, `platform`, `user_segment`, `abgroup`, `age`, and `engagement_score`.
   - Introduced pre-computed indexes for `country`, `platform`, and `user_segment` to optimize effect calculations.

3. **Effect Calculations**:
   - Calculated category effects for countries, platforms, and user segments using vectorized operations.
   - Included group effects with added randomness based on the `abgroup`.

4. **Noise and Non-linear Components**:
   - Incorporated noise and non-linear components into the final 'value' and 'pre_test_value' calculations to mimic real-world data variability.

#### Benefits:
- Allows for effective testing of the CUPED methodology by providing synthetic datasets with controllable correlation.
- Facilitates model validation and performance tuning, especially for models like CUPED_GBOOST.

#### Usage:
- The `generate_synthetic_data` function now accepts a `correlation_level` parameter to set the desired level of correlation between 'value' and 'pre_test_value'.
- Example usage:
  ```python
  df = generate_synthetic_data(
      num_users=1000,
      countries=['USA', 'Canada', 'UK'],
      platforms=['iOS', 'Android'],
      user_segments=['Segment1', 'Segment2', 'Segment3'],
      ab_groups=['a', 'b', 'c'],
      base_increase_percentage=0.1,
      noise_level=1.0,
      correlation_level=0.5,
      seed=40
  )