### PR TITLE
rename Variatio to ABTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# Variatio
+# AB Test Advanced Toolkit
+
 [![PyPI version](https://img.shields.io/pypi/v/variatio.svg)](https://pypi.org/project/variatio/)
 [![Python](https://github.com/dmitry-brazhenko/SharpToken/actions/workflows/build-test-and-publish.yml/badge.svg?branch=main)](https://github.com/dmitry-brazhenko/SharpToken/actions/workflows/build-test-and-publish.yml)
 [![GitHub Issues](https://img.shields.io/github/issues/dmitry-brazhenko/Variatio.svg)](https://github.com/dmitry-brazhenko/Variatio/issues)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-Variatio is an experimental Python library designed for advanced A/B testing analysis. It leverages statistical techniques and machine learning, including variance reduction through CUPED and integration with XGBoost for predictive insights. Variatio is ideal for data scientists and researchers looking to obtain deeper insights from their A/B testing efforts.
+AB Test Advanced Toolkit is an experimental Python library designed for advanced A/B testing analysis. It leverages statistical techniques and machine learning, including variance reduction through CUPED and integration with XGBoost for predictive insights. AB Test Advanced Toolkit is ideal for data scientists and researchers looking to obtain deeper insights from their A/B testing efforts.
 
 ## Features
 
@@ -13,29 +14,27 @@ This tool streamlines A/B testing by automatically calculating all the classic m
 - **Statistical Significance Testing:** Easily compare metrics between control and test groups, with all necessary calculations done for you.
 - **CUPED Adjustments:** This experimental extension utilizes Controlled-experiment Using Pre-Experiment Data (CUPED) techniques for variance reduction. It innovatively employs user properties as covariates and leverages XGBoost regression, moving beyond traditional linear approaches to enhance A/B test sensitivity.
 
-
-
 ## Installation
 
 ```bash
 pip install ab_test_advanced_toolkit
 ```
 
-or install Variatio directly from the source:
+or install AB Test Advanced Toolkit directly from the source:
 
 ```bash
-git clone https://github.com/dmitry_brazhenko/Variatio.git
-cd Variatio
+git clone https://github.com/dmitry-brazhenko/ab-test-advanced-toolkit.git
+cd ab_test_advanced_toolkit
 pip install .
 ```
 
 ## Data Preparation
 
-To use Variatio effectively, you need to prepare three main types of data:
+To use AB Test Advanced Toolkit effectively, you need to prepare three main types of data:
 
 ### 1. Event Data
 
-The `event_data` is crucial for analysis in Variatio. It tracks user interactions and should include the following mandatory columns:
+The `event_data` is crucial for analysis in AB Test Advanced Toolkit. It tracks user interactions and should include the following mandatory columns:
 
 - `timestamp`: The date and time when the event occurred.
 - `userid`: A unique identifier for the user who triggered the event.
@@ -71,8 +70,6 @@ The `ab_test_allocations` dataset is essential for understanding the distributio
 | 2022-12-15 03:00:00 | 4      | B       |
 | 2022-12-15 04:00:00 | 5      | A       |
 
-
-
 ### 3. User Properties Data Sample (Optional)
 
 This optional `user_properties` dataset can enhance the analysis with user demographic or behavioral data. The `userid` column must match the `event_data` and `ab_test_allocations` datasets.
@@ -85,13 +82,12 @@ This optional `user_properties` dataset can enhance the analysis with user demog
 | 4      | 32  | Female | UK         | Tablet      | Free              |
 | 5      | 60  | Male   | Germany    | Tablet      | Free              |
 
+## Using ABTestAnalyzer
 
-## Using VariatioAnalyzer
-
-After preparing your datasets, you can use `VariatioAnalyzer` to perform A/B testing analysis. Initialize the analyzer with your datasets and specify the control group:
+After preparing your datasets, you can use `ABTestAnalyzer` to perform A/B testing analysis. Initialize the analyzer with your datasets and specify the control group:
 
 ```python
-from variatio import VariatioAnalyzer
+from ab_test_advanced_toolkit.analyzer import ABTestAnalyzer
 import pandas as pd
 
 event_data = pd.DataFrame({
@@ -122,7 +118,7 @@ user_properties = pd.DataFrame({
     "membership_status": ["Free", "Free", "Free", "Free", "Free"]
 })
 
-analyzer = VariatioAnalyzer(event_data, user_allocations, "A", user_properties, mode="gboost_cuped")
+analyzer = ABTestAnalyzer(event_data, user_allocations, "A", user_properties, mode="gboost_cuped")
 ```
 
 You can then calculate various metrics such as event count per user, attribute sum per user (useful for calculating metrics like ARPU), or conversion rates to specific events:
@@ -148,30 +144,25 @@ analyzer.save_report("abtest_report.html")
 
 Here's a sample report showcasing meticulously calculated metrics, organized in an easy-to-analyze table format.
 
-![](examples/metrics_example.png)
-
+![Metrics Example](examples/metrics_example.png)
 
 ## Contribution Guidelines
 
-We welcome contributions to Variatio! If you'd like to contribute, please follow these guidelines:
+We welcome contributions to AB Test Advanced Toolkit! If you'd like to contribute, please follow these guidelines:
 
 - Fork the repository and create your feature branch.
 - Make sure your code adheres to the project's coding standards.
 - Submit a pull request with a detailed description of your changes.
 
-
-
 ## License
 
-Variatio is licensed under the MIT License. See [LICENSE](LICENSE) for more details.
+AB Test Advanced Toolkit is licensed under the MIT License. See [LICENSE](LICENSE) for more details.
 
 ## Disclaimer
 
-Variatio is shared with the community as an experimental library, offered "as-is" and without any warranties. Your explorations and tests with it are encouraged, but please proceed with awareness of its experimental nature. We're keen to hear about your experiences and eager to tackle any challenges you encounter. Should you have questions or face any issues, don't hesitate to open an issue in our repository. We welcome your feedback and contributions to make Variatio even better!# tmp_abtest_lib
+AB Test Advanced Toolkit is shared with the community as an experimental library, offered "as-is" and without any warranties. Your explorations and tests with it are encouraged, but please proceed with awareness of its experimental nature. We're keen to hear about your experiences and eager to tackle any challenges you encounter. Should you have questions or face any issues, don't hesitate to open an issue in our repository. We welcome your feedback and contributions to make AB Test Advanced Toolkit even better!
 
-# tmp_abtest_lib
-
-# Tests
+## Tests
 
 ```bash
 pytest

--- a/ab_test_advanced_toolkit/__init__.py
+++ b/ab_test_advanced_toolkit/__init__.py
@@ -1,1 +1,1 @@
-from .analyzer import VariatioAnalyzer
+from .analyzer import ABTestAnalyzer

--- a/ab_test_advanced_toolkit/analyzer.py
+++ b/ab_test_advanced_toolkit/analyzer.py
@@ -16,11 +16,11 @@ def setup_logging(level=logging.INFO):
     logger = logging.getLogger(__name__)
     return logger
 
-class VariatioAnalyzer:
+class ABTestAnalyzer:
     def __init__(self, event_data: pd.DataFrame, ab_test_allocations: pd.DataFrame, control_group_name: str,
                  user_properties: Optional[pd.DataFrame] = None, mode="gboost_cuped", logging_level=logging.INFO):
         """
-        Initializes the VariatioAnalyzer with event data, AB test allocations, control group name, user properties, and mode.
+        Initializes the ABTestAnalyzer with event data, AB test allocations, control group name, user properties, and mode.
         :param event_data: DataFrame containing event data. Expected pandas format: |timestamp|userid|event_name|attribute_1|attribute_2|...
         :param ab_test_allocations: DataFrame containing AB test allocations. Expected pandas format: |timestamp|userid|abgroup|
         :param control_group_name: The name of the control group.

--- a/data_generation/data_generator.py
+++ b/data_generation/data_generator.py
@@ -2,7 +2,7 @@ import os
 import datetime
 import pandas as pd
 import numpy as np
-from ab_test_advanced_toolkit.analyzer import VariatioAnalyzer
+from ab_test_advanced_toolkit.analyzer import ABTestAnalyzer
 from typing import Tuple
 
 import logging
@@ -127,15 +127,15 @@ def run_analysis(df: pd.DataFrame):
     event_data, user_allocations, user_properties = create_dataframes(df)
     
     # Analysis without enhancement
-    analyzer_no_enhancement = VariatioAnalyzer(event_data, user_allocations, "a1", user_properties, mode="no_enhancement")
+    analyzer_no_enhancement = ABTestAnalyzer(event_data, user_allocations, "a1", user_properties, mode="no_enhancement")
     results_no_enhancement = analyzer_no_enhancement.calculate_event_attribute_sum_per_user('purchase', 'purchase_value')
 
     # Analysis with CUPED
-    analyzer_cuped = VariatioAnalyzer(event_data, user_allocations, "a1", user_properties, mode="cuped")
+    analyzer_cuped = ABTestAnalyzer(event_data, user_allocations, "a1", user_properties, mode="cuped")
     results_cuped = analyzer_cuped.calculate_event_attribute_sum_per_user('purchase', 'purchase_value')
 
     # Analysis with gboost CUPED
-    analyzer_gboost_cuped = VariatioAnalyzer(event_data, user_allocations, "a1", user_properties, mode="gboost_cuped")
+    analyzer_gboost_cuped = ABTestAnalyzer(event_data, user_allocations, "a1", user_properties, mode="gboost_cuped")
     results_gboost_cuped = analyzer_gboost_cuped.calculate_event_attribute_sum_per_user('purchase', 'purchase_value')
 
     return {

--- a/examples/example.ipynb
+++ b/examples/example.ipynb
@@ -18,6 +18,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Importing pandas and ABTestAnalyzer"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -25,20 +32,13 @@
    "source": []
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Importing pandas and VariatioAnalyzer"
-   ]
-  },
-  {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
     "import pandas as pd\n",
-    "from ab_test_advanced_toolkit import VariatioAnalyzer"
+    "from ab_test_advanced_toolkit import ABTestAnalyzer"
    ]
   },
   {
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -85,7 +85,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -121,23 +121,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
-    "analyzer = VariatioAnalyzer(event_data, user_allocations, \"A\", mode=\"gboost_cuped\")"
+    "analyzer = ABTestAnalyzer(event_data, user_allocations, \"A\", mode=\"gboost_cuped\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2024-05-21 11:11:48,722 - INFO - X_control:         event_name\n",
+      "2024-05-25 17:18:55,007 - INFO - X_control:         event_name\n",
       "userid            \n",
       "1              0.0\n",
       "5              0.0\n",
@@ -152,8 +152,8 @@
       "10000          0.0\n",
       "\n",
       "[5076 rows x 1 columns]\n",
-      "2024-05-21 11:11:48,755 - INFO - Model was fit\n",
-      "2024-05-21 11:11:48,770 - INFO - X_control:         purchase_value\n",
+      "2024-05-25 17:18:55,079 - INFO - Model was fit\n",
+      "2024-05-25 17:18:55,097 - INFO - X_control:         purchase_value\n",
       "userid                \n",
       "1                  0.0\n",
       "5                  0.0\n",
@@ -168,7 +168,7 @@
       "10000              0.0\n",
       "\n",
       "[5076 rows x 1 columns]\n",
-      "2024-05-21 11:11:48,805 - INFO - Model was fit\n"
+      "2024-05-25 17:18:55,135 - INFO - Model was fit\n"
      ]
     },
     {
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -219,7 +219,7 @@
        " <Metric(metrictype=MetricType.CONVERSION_RATE, metricparams=<MetricParams({'event_name': 'login'})>, result=<MetricResult(control_group=A, test_groups=['B'], data={'A': 0.08490937746256895, 'B': 0.30584890333062553}, stat_significance={'B': 7.418608501468872e-175}, stat_significance_method=StatSignificanceMethod.T_TEST)>)>]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -1,7 +1,7 @@
 import pytest
 import logging
 
-from ab_test_advanced_toolkit import VariatioAnalyzer
+from ab_test_advanced_toolkit import ABTestAnalyzer
 from ab_test_advanced_toolkit.metrics import MetricType
 from tests.test_utils import generate_event_data, generate_user_properties, generate_user_allocations
 
@@ -16,10 +16,10 @@ def test_library_is_initialized():
     ab_test_allocations = generate_user_allocations()
 
     # initializing with user properties
-    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="gboost_cuped")
+    analyzer = ABTestAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="gboost_cuped")
 
     # initializing without user properties
-    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="gboost_cuped")
+    analyzer = ABTestAnalyzer(event_data, ab_test_allocations, "A", mode="gboost_cuped")
 
 
 def test_library_is_not_initialized():
@@ -30,7 +30,7 @@ def test_library_is_not_initialized():
 
     # initializing without user properties
     with pytest.raises(Exception) as e_info:
-        VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="gboost_cuped")
+        ABTestAnalyzer(event_data, ab_test_allocations, "A", mode="gboost_cuped")
     assert str("The 'timestamp' column in event_data must be of datetime type.") == str(e_info.value)
 
 
@@ -41,7 +41,7 @@ def test_calculate_metrics(user_properties):
     event_data = generate_event_data()
     ab_test_allocations = generate_user_allocations()
 
-    analyzer = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="gboost_cuped")
+    analyzer = ABTestAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="gboost_cuped")
 
     event_counts = analyzer.calculate_event_count_per_user('purchase')
 
@@ -73,8 +73,8 @@ def test_calculate_significance():
     ab_test_allocations = generate_user_allocations()
 
     user_properties = generate_user_properties()
-    analyzer_user_properties = VariatioAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="gboost_cuped")
-    analyzer_no_user_properties = VariatioAnalyzer(event_data, ab_test_allocations, "A", mode="gboost_cuped")
+    analyzer_user_properties = ABTestAnalyzer(event_data, ab_test_allocations, "A", user_properties, mode="gboost_cuped")
+    analyzer_no_user_properties = ABTestAnalyzer(event_data, ab_test_allocations, "A", mode="gboost_cuped")
 
     analyzer_user_properties.calculate_event_count_per_user('purchase')
     analyzer_no_user_properties.calculate_event_count_per_user('purchase')


### PR DESCRIPTION
# Refactoring: Rename `VariatioAnalyzer` to `ABTestAnalyzer`

## Description

This pull request includes a series of refactoring changes aimed at improving the clarity and consistency of our codebase. The main change involves renaming the `VariatioAnalyzer` class to `ABTestAnalyzer` across various files. This renaming aligns better with our project's focus on A/B testing and enhances readability.

## Changes Made
- Renamed the `VariatioAnalyzer` class to `ABTestAnalyzer` in `analyzer.py`.
- Updated all references to `VariatioAnalyzer` across the project files, including:
  - Function definitions
  - Variable names
  - Documentation strings
  - Test cases
- Ensured all import statements reflect the new class name.

## Testing
- All existing unit tests have been run to ensure no functionality is broken.
- Manual testing has been performed to verify that the changes integrate smoothly with the rest of the project.

## Motivation
The renaming improves code clarity and makes the purpose of the class more evident to new contributors and existing team members.
