### PR TITLE
Update analyzer.py

### DIFF
--- a/ab_test_advanced_toolkit/analyzer.py
+++ b/ab_test_advanced_toolkit/analyzer.py
@@ -134,7 +134,7 @@ class ABTestAnalyzer:
 
         if attribute_name not in self.event_data.columns:
             raise ValueError(f"Attribute {attribute_name} not found in event data.")
-        if self.event_data[attribute_name].dtype not in [int, float]:
+        if not pd.api.types.is_numeric_dtype(self.event_data[attribute_name])
             raise ValueError(f"Attribute {attribute_name} is not numeric.")
 
         merged_pretest, _ = self._merge_and_aggregate(self.event_data, self.ab_test_allocations, event_name,

--- a/ab_test_advanced_toolkit/analyzer.py
+++ b/ab_test_advanced_toolkit/analyzer.py
@@ -134,7 +134,7 @@ class ABTestAnalyzer:
 
         if attribute_name not in self.event_data.columns:
             raise ValueError(f"Attribute {attribute_name} not found in event data.")
-        if not pd.api.types.is_numeric_dtype(self.event_data[attribute_name])
+        if not pd.api.types.is_numeric_dtype(self.event_data[attribute_name]):
             raise ValueError(f"Attribute {attribute_name} is not numeric.")
 
         merged_pretest, _ = self._merge_and_aggregate(self.event_data, self.ab_test_allocations, event_name,


### PR DESCRIPTION
Python 3.11 support

Previous logic is failing on repo example because pandas int64 is different type from int:
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/d7fef965-6cd1-4cd9-b432-3a1839f0d17a">
